### PR TITLE
Fix automatic error badge cleanup

### DIFF
--- a/src/scripts/_parser.js
+++ b/src/scripts/_parser.js
@@ -109,12 +109,14 @@ async function loadFeeds() {
                 errorElement.remove()
                 metaColorChanger()
             })
-        if (existingError) {
-            setInterval(function () {
-                existingError.remove()
+
+        // Auto-remove the error after some time if not closed manually
+        setTimeout(function () {
+            if (errorElement.isConnected) {
+                errorElement.remove()
                 metaColorChanger()
-            }, 15000)
-        }
+            }
+        }, 15000)
     }
 
     // Only return hideWelcome on initial load


### PR DESCRIPTION
## Summary
- clean up error badges after 15s using the newly created element

## Testing
- `npm run build` *(fails: parcel not found)*

------
https://chatgpt.com/codex/tasks/task_e_684134a725c08328846888dcb8a0f426