### PR TITLE
Fix iOS PWA safe-area spacing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,10 @@
     <head>
         <meta charset="UTF-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+        />
         <title>Start.</title>
         <link rel="stylesheet" href="../src/styles/base.scss" />
         <link rel="manifest" href="./assets/icons/site.webmanifest" />

--- a/src/styles/_main.scss
+++ b/src/styles/_main.scss
@@ -12,7 +12,7 @@
         box-sizing: border-box;
         height: calc(100vh - var(--marginSize) * 2);
         border-radius: var(--borderRadius);
-        padding: 0 0 var(--paddingSize) 0;
+        padding: 0 0 calc(var(--paddingSize) + env(safe-area-inset-bottom)) 0;
         margin: var(--marginSize) 0;
         overflow-y: scroll;
         position: relative;
@@ -141,7 +141,7 @@
 .admin {
     position: fixed;
     z-index: 997;
-    bottom: var(--marginSize);
+    bottom: calc(var(--marginSize) + env(safe-area-inset-bottom));
     right: var(--marginSize);
     padding: 0 var(--marginSize);
     height: var(--adminHeight);
@@ -184,7 +184,10 @@
         &__column {
             width: calc(100vw - var(--marginSize) * 2);
             padding: 0 var(--paddingSize)
-                calc(var(--paddingSize) + var(--adminHeight)) var(--paddingSize);
+                calc(
+                    var(--paddingSize) + var(--adminHeight) +
+                        env(safe-area-inset-bottom)
+                ) var(--paddingSize);
             min-width: auto;
             scroll-snap-align: center;
             min-block-size: calc(100vw - var(--marginSize) * 2);

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -15,6 +15,7 @@
 body {
     padding: 0;
     margin: 0;
+    padding-bottom: env(safe-area-inset-bottom);
     background-color: var(--bgColor);
     font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
         Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue',


### PR DESCRIPTION
## Summary
- ensure viewport uses `viewport-fit=cover` for safe-area support
- add bottom safe-area padding and offsets to layouts and admin panel

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aea9b7798483288497e1701cfac54a